### PR TITLE
Check all three(!) locations where flow control mode is stored

### DIFF
--- a/sys/dev/ixgbe/if_ix.c
+++ b/sys/dev/ixgbe/if_ix.c
@@ -3998,7 +3998,7 @@ ixgbe_sysctl_flowcntl(SYSCTL_HANDLER_ARGS)
 		return (error);
 
 	/* Don't bother if it's not changed */
-	if (fc == adapter->hw.fc.current_mode)
+	if (fc == adapter->hw.fc.current_mode && fc == adapter->hw.fc.requested_mode && fc == adapter->fc)
 		return (0);
 
 	return ixgbe_set_flowcntl(adapter, fc);


### PR DESCRIPTION
The sysctl handler would abort early if the adapter->hw.fc.current_mode
was equal to the requested mode, but flow control settings are
stored in three different variables:
adapter->hw.fc.current_mode
adapter->hw.fc.requested_mode
adapter->fc

In some cases, /etc/sysctl.conf was applied during autonegotiation,
which would result in the requested_mode being copied into the
current_mode, and leaving adapter->fc inconsistant.

Checking all three when the sysctl is set makes /etc/sysctl.conf work
as expected.