### PR TITLE
Pass rid == -1 to iflib_softirq_alloc_generic() for bnxt

### DIFF
--- a/sys/dev/bnxt/if_bnxt.c
+++ b/sys/dev/bnxt/if_bnxt.c
@@ -1562,7 +1562,8 @@ bnxt_msix_intr_assign(if_ctx_t ctx, int msix)
 	}
 
 	for (i=0; i<softc->scctx->isc_ntxqsets; i++)
-		iflib_softirq_alloc_generic(ctx, i + 1, IFLIB_INTR_TX, NULL, i,
+		/* TODO: Benchmark and see if tying to the RX irqs helps */
+		iflib_softirq_alloc_generic(ctx, -1, IFLIB_INTR_TX, NULL, i,
 		    "tx_cp");
 
 	return rc;


### PR DESCRIPTION
bnxt doesn't use shared interrupts, so there should be no need to
try to get TX queues on corresponding RX interrupt CPUs.  This
sbould be benchmarked and verified.  If it does need to set affinity,
look at how ixgbe and e1000 do it since the rid should not be the
qidx anymore.